### PR TITLE
Setting organization header properly using extendContext

### DIFF
--- a/cube.js
+++ b/cube.js
@@ -1,7 +1,7 @@
 module.exports = {
   contextToAppId: (context) => `CUBEJS_APP_${context.tenantSchema}`,
   extendContext: (req) => {
-    return {"tenantSchema": req.headers.organization}
+    return { tenantSchema: req.headers.organization };
   },
   http: {
     cors: {

--- a/cube.js
+++ b/cube.js
@@ -1,9 +1,7 @@
 module.exports = {
-  contextToAppId: ({ securityContext }) =>
-    `CUBEJS_APP_${securityContext.tenantSchema}`,
-  checkAuth: (req, token) => {
-    const tenantSchema = req.headers["organization"];
-    req.securityContext = { tenantSchema };
+  contextToAppId: (context) => `CUBEJS_APP_${context.tenantSchema}`,
+  extendContext: (req) => {
+    return {"tenantSchema": req.headers.organization}
   },
   http: {
     cors: {

--- a/cube.js
+++ b/cube.js
@@ -1,7 +1,7 @@
 module.exports = {
   contextToAppId: (context) => `CUBEJS_APP_${context.tenantSchema}`,
-  extendContext: (req) => {
-    return { tenantSchema: req.headers.organization };
+  extendContext: (request) => {
+    return { tenantSchema: request.headers.organization };
   },
   http: {
     cors: {

--- a/schema/Item.js
+++ b/schema/Item.js
@@ -1,5 +1,7 @@
+const { tenantSchema } = COMPILE_CONTEXT;
+
 cube(`Item`, {
-  sql: `SELECT * FROM public.item`,
+  sql: `SELECT * FROM ${tenantSchema}.item`,
 
   joins: {
     Plio: {

--- a/schema/Plio.js
+++ b/schema/Plio.js
@@ -1,7 +1,4 @@
-const {
-  securityContext: { tenantSchema },
-} = COMPILE_CONTEXT;
-// const { organizationTenantSchema } = COMPILE_CONTEXT;
+const { tenantSchema } = COMPILE_CONTEXT;
 
 cube(`Plio`, {
   sql: `SELECT * FROM ${tenantSchema}.plio`,

--- a/schema/Question.js
+++ b/schema/Question.js
@@ -1,5 +1,7 @@
+const { tenantSchema } = COMPILE_CONTEXT;
+
 cube(`Question`, {
-  sql: `SELECT * FROM public.question`,
+  sql: `SELECT * FROM ${tenantSchema}.question`,
 
   joins: {
     Item: {

--- a/schema/Session.js
+++ b/schema/Session.js
@@ -1,7 +1,4 @@
-const {
-  securityContext: { tenantSchema },
-} = COMPILE_CONTEXT;
-// const { organizationTenantSchema } = COMPILE_CONTEXT;
+const { tenantSchema } = COMPILE_CONTEXT;
 
 cube(`Session`, {
   sql: `SELECT * FROM ${tenantSchema}.session`,

--- a/schema/SessionAnswer.js
+++ b/schema/SessionAnswer.js
@@ -1,5 +1,7 @@
+const { tenantSchema } = COMPILE_CONTEXT;
+
 cube(`SessionAnswer`, {
-  sql: `SELECT * FROM public.session_answer`,
+  sql: `SELECT * FROM ${tenantSchema}.session_answer`,
 
   joins: {
     Session: {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-analytics) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-analytics#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #8 

## Summary

1. Using `extendContext` to pick header from ExpressJS `req` object. This will avoid using `checkAuth` which was overriding the default authentication functionality.

## Testing
Tested locally on cubejs prod mode. Things seem to be working fine.